### PR TITLE
added __eq__ in event.Quit definition

### DIFF
--- a/tdl/event.py
+++ b/tdl/event.py
@@ -92,6 +92,12 @@ class Quit(Event):
     __slots__ = ()
     type = 'QUIT'
 
+    def __eq__(self, other):
+        """Grants eqaulity between any two instances of Quit.
+        Useful for `event.Quit() in tdl.event.get() kinds of comparisions.`
+        """
+        return isinstance(other, Quit)
+
 class KeyEvent(Event):
 
     def __init__(self, key, char, lalt, lctrl, ralt, rctrl, shift):
@@ -476,4 +482,3 @@ App.runOnce = _style.backport(App.run_once)
 keyWait = _style.backport(key_wait)
 setKeyRepeat = _style.backport(set_key_repeat)
 isWindowClosed = _style.backport(is_window_closed)
-


### PR DESCRIPTION
Makes this work:

```python
import tdl

for event in tdl.event.get():
    if event == tdl.event.Quit():
        # trigger shutdown
```