### PR TITLE
Feature/image blit

### DIFF
--- a/tdl/__init__.py
+++ b/tdl/__init__.py
@@ -787,6 +787,32 @@ class _BaseConsole(object):
         x, y = position
         return (0 <= x < self.width) and (0 <= y < self.height)
 
+    def blit_image(self, image, x, y, subcell_res=False):
+        """Blits a rectangular part of an image onto a console, with or without
+           subcell resultion.
+
+        @type image: str
+        @param image: string indicating name of image file in working directory.
+
+        @type x: int
+        @param x: X coordinate in the console of the upper-left corner of the image.
+        @type y: int
+        @param y: Y coordinate in the console of the upper-left corner of the image.
+
+        @type subcell_res: boolean
+        @param subcell_res: Can be set to True to double the console resolution 
+                             using the libtcod blitting function image_blit_2x.
+        """
+
+        tdl_image = _lib.TCOD_image_load(_encodeString(image))
+
+        if subcell_res:
+            _lib.TCOD_image_blit_2x(tdl_image, self.tcod_console, x, y, 0, 0, -1, -1)
+
+        else:
+            _lib.TCOD_image_blit_rect(tdl_image, self.tcod_console, x, y, -1, -1,
+                                      _lib.TCOD_BKGND_SET)
+
 class Console(_BaseConsole):
     """Contains character and color data and can be drawn to.
 

--- a/tdl/__init__.py
+++ b/tdl/__init__.py
@@ -787,7 +787,7 @@ class _BaseConsole(object):
         x, y = position
         return (0 <= x < self.width) and (0 <= y < self.height)
 
-    def blit_image(self, image, x, y, subcell_res=False):
+    def image_blit(self, image, x, y, subcell_res=False):
         """Blits a rectangular part of an image onto a console, with or without
            subcell resultion.
 


### PR DESCRIPTION
Hi! I'm working on "Roguelike Tutorial, using python3+tdl" on roguebasin. It's based on Jotaf's "Complete Roguelike Tutorial, using python+libtcod".

http://www.roguebasin.com/index.php?title=Roguelike_Tutorial,_using_python3%2Btdl

For part 10, there's a call to tcod's image_blit_2x.

In this fork, I've added an image_blit method to _BaseConsole. It takes the name of an image as a string and x/y coordinates for the placement of the upper left corner. It converts the image to a TCOD image and passes the variables to TCOD_image_blit_2x or TCOD_image_blit_rect depending on a flag called "subcell_res". In the future, it could also be used to allow image scaling and through TCOD_image_blit.

It would be great if you would be willing to add this the master branch. I can provide the project I used for testing on request.

Thanks!
Will