### PR TITLE
Fix Window.get_char() error (one argument instead of two)

### DIFF
--- a/tdl/__init__.py
+++ b/tdl/__init__.py
@@ -996,7 +996,7 @@ class Window(_BaseConsole):
     def get_char(self, x, y):
         # inherit docstring
         x, y = self._normalizePoint(x, y)
-        return self.console.get_char(self._translate(x, y))
+        return self.console.get_char(*self._translate(x, y))
 
     def __repr__(self):
         return "<Window(X=%i Y=%i Width=%i Height=%i)>" % (self.x, self.y,

--- a/tdl/__init__.py
+++ b/tdl/__init__.py
@@ -996,7 +996,8 @@ class Window(_BaseConsole):
     def get_char(self, x, y):
         # inherit docstring
         x, y = self._normalizePoint(x, y)
-        return self.console.get_char(*self._translate(x, y))
+        xtrans, ytrans = self._translate(x, y)
+        return self.console.get_char(xtrans, ytrans)
 
     def __repr__(self):
         return "<Window(X=%i Y=%i Width=%i Height=%i)>" % (self.x, self.y,


### PR DESCRIPTION
You have a bug in Window.get_char() method. Window._translate() method returns a tuple with translated points, so you need to pass two arguments in get_char() method in line 999, not one.